### PR TITLE
Vs support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,29 +24,33 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 configure_file ( config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/config.h )
 
-iconv_configure_file (LIBRARY_NAME libiconv 
+iconv_configure_file (LIBRARY_NAME iconv 
   INPUT include/iconv.h.build.in 
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/iconv.h )
 
-iconv_configure_file (LIBRARY_NAME libiconv 
+iconv_configure_file (LIBRARY_NAME iconv 
   INPUT srclib/alloca.in.h 
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/alloca.h )
 
-iconv_configure_file (LIBRARY_NAME libiconv 
+iconv_configure_file (LIBRARY_NAME iconv 
   INPUT include/iconv.h.build.in 
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/iconv.h )
 
-iconv_configure_file (LIBRARY_NAME libiconv 
+iconv_configure_file (LIBRARY_NAME iconv 
   INPUT srclib/unistd.in.h 
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/unistd.h @ONLY)
 
-iconv_configure_file (LIBRARY_NAME libiconv 
+iconv_configure_file (LIBRARY_NAME iconv 
   INPUT srclib/unitypes.in.h 
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/unitypes.h )
 
-iconv_configure_file (LIBRARY_NAME libcharset
+iconv_configure_file (LIBRARY_NAME charset
   INPUT libcharset/include/libcharset.h.in 
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/libcharset.h )
+
+iconv_configure_file (LIBRARY_NAME charset
+  INPUT libcharset/include/localcharset.h.build.in 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/localcharset.h )
 
 # Dirty fix for MinGW
 if ( MINGW )
@@ -63,13 +67,11 @@ set ( SRC_LIBCHARSET
   libcharset/lib/relocatable.c
 )
 
-if (MSVC)
-  add_library ( charset STATIC ${SRC_LIBCHARSET} )
-else()
-  add_library ( charset ${SRC_LIBCHARSET} )
+add_library ( charset ${SRC_LIBCHARSET} )
+if(NOT MSVC)
   target_compile_options(charset PRIVATE -DBUILDING_DLL)
 endif()
-target_compile_options ( charset PRIVATE -DBUILDING_LIBCHARSET)
+target_compile_options (charset PRIVATE -DBUILDING_LIBCHARSET)
 
 if (NOT MSVC)
   # libicrt
@@ -114,4 +116,5 @@ endif()
 install_library ( iconv charset )
 install_header ( ${CMAKE_CURRENT_BINARY_DIR}/include/iconv.h )
 install_header ( ${CMAKE_CURRENT_BINARY_DIR}/include/libcharset.h )
+install_header ( ${CMAKE_CURRENT_BINARY_DIR}/include/localcharset.h )
 install_data ( README AUTHORS COPYING )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,26 @@ set ( BROKEN_WCHAR_H 0 )
 set ( HAVE_WCHAR_T 0)
 
 configure_file ( config.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/config.h )
-configure_file ( include/iconv.h.build.in ${CMAKE_CURRENT_SOURCE_DIR}/include/iconv.h )
-configure_file ( libcharset/include/libcharset.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h )
-configure_file ( srclib/uniwidth.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/uniwidth.h )
-configure_file ( srclib/unitypes.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/unitypes.h )
+
+if(MSVC)
+  iconv_configure_file (LIBRARY_NAME libiconv 
+    INPUT include/iconv.h.build.in 
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/iconv.h )
+
+  iconv_configure_file (LIBRARY_NAME libcharset 
+    INPUT libcharset/include/libcharset.h.in 
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h )
+  
+  configure_file (srclib/alloca.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/alloca.h )
+  configure_file (srclib/unistd.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/unistd.h @ONLY)
+else()
+  configure_file (include/iconv.h.build.in ${CMAKE_CURRENT_SOURCE_DIR}/include/iconv.h )
+  configure_file (libcharset/include/libcharset.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h )
+endif()
+
+configure_file (srclib/uniwidth.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/uniwidth.h )
+configure_file (srclib/unitypes.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/unitypes.h )
+
 
 # Dirty fix for MinGW
 if ( MINGW )
@@ -41,31 +57,32 @@ set ( SRC_LIBCHARSET
   libcharset/lib/relocatable.c
 )
 
-add_library ( charset ${SRC_LIBCHARSET} )
+add_library ( charset STATIC ${SRC_LIBCHARSET} )
 set_target_properties ( charset PROPERTIES COMPILE_FLAGS -DBUILDING_LIBCHARSET)
 
-# libicrt
-set ( SRC_LIBICRT 
-  srclib/allocator.c
-  srclib/areadlink.c
-  srclib/careadlinkat.c
-  srclib/malloca.c
-  srclib/progname.c
-  srclib/safe-read.c
-  srclib/uniwidth/width.c
-  srclib/xmalloc.c
-  srclib/xstrdup.c
-  srclib/xreadlink.c
-  srclib/canonicalize-lgpl.c
-  srclib/error.c
-  srclib/lstat.c
-  srclib/readlink.c
-  srclib/stat.c
-  srclib/strerror.c
-  srclib/strerror-override.c  
-)
-add_library ( icrt STATIC ${SRC_LIBICRT} )
-
+if (NOT MSVC)
+  # libicrt
+  set ( SRC_LIBICRT 
+    srclib/allocator.c
+    srclib/areadlink.c
+    srclib/careadlinkat.c
+    srclib/malloca.c
+    srclib/progname.c
+    srclib/safe-read.c
+    srclib/uniwidth/width.c
+    srclib/xmalloc.c
+    srclib/xstrdup.c
+    srclib/xreadlink.c
+    srclib/canonicalize-lgpl.c
+    srclib/error.c
+    srclib/lstat.c
+    srclib/readlink.c
+    srclib/stat.c
+    srclib/strerror.c
+    srclib/strerror-override.c  
+  )
+  add_library ( icrt STATIC ${SRC_LIBICRT} )
+endif()
 # libiconv
 set ( SRC_LIBICONV
   lib/iconv.c
@@ -75,11 +92,14 @@ add_library ( iconv ${SRC_LIBICONV} )
 target_link_libraries ( iconv charset )
 set_target_properties ( iconv PROPERTIES COMPILE_FLAGS -DBUILDING_LIBICONV)
 
-add_executable ( iconvcli src/iconv_no_i18n.c )
-target_link_libraries ( iconvcli iconv icrt charset )
-set_target_properties ( iconvcli PROPERTIES OUTPUT_NAME iconv )
+if(NOT MSVC)
+  add_executable ( iconvcli src/iconv_no_i18n.c )
+  target_link_libraries ( iconvcli iconv icrt charset )
+  set_target_properties ( iconvcli PROPERTIES OUTPUT_NAME iconv )
+
+  install_executable ( iconvcli )
+endif()
 
 install_library ( iconv charset )
-install_executable ( iconvcli )
 install_header ( include/iconv.h )
 install_data ( README AUTHORS COPYING )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,7 @@ include ( configure )
 
 # Options
 option ( ENABLE_EXTRA "Enable a few rarely used encodings" OFF)
-option ( ENABLE_NLS "Translation of program messages to the user's native
-   language is requested" OFF)
+option ( ENABLE_NLS "Translation of program messages to the user's native language is requested" OFF)
 #option ( ENABLE_RELOCATABLE "The package shall run at any location in the file system" ON )
 
 # iconv.h
@@ -20,27 +19,34 @@ set ( USE_MBSTATE_T 1 )
 set ( BROKEN_WCHAR_H 0 )
 set ( HAVE_WCHAR_T 0)
 
-configure_file ( config.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/config.h )
+# setup default include directories 
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
-if(MSVC)
-  iconv_configure_file (LIBRARY_NAME libiconv 
-    INPUT include/iconv.h.build.in 
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/iconv.h )
+configure_file ( config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 
-  iconv_configure_file (LIBRARY_NAME libcharset 
-    INPUT libcharset/include/libcharset.h.in 
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h )
-  
-  configure_file (srclib/alloca.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/alloca.h )
-  configure_file (srclib/unistd.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/unistd.h @ONLY)
-else()
-  configure_file (include/iconv.h.build.in ${CMAKE_CURRENT_SOURCE_DIR}/include/iconv.h )
-  configure_file (libcharset/include/libcharset.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h )
-endif()
+iconv_configure_file (LIBRARY_NAME libiconv 
+  INPUT include/iconv.h.build.in 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/iconv.h )
 
-configure_file (srclib/uniwidth.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/uniwidth.h )
-configure_file (srclib/unitypes.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/unitypes.h )
+iconv_configure_file (LIBRARY_NAME libiconv 
+  INPUT srclib/alloca.in.h 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/alloca.h )
 
+iconv_configure_file (LIBRARY_NAME libiconv 
+  INPUT include/iconv.h.build.in 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/iconv.h )
+
+iconv_configure_file (LIBRARY_NAME libiconv 
+  INPUT srclib/unistd.in.h 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/unistd.h)
+
+iconv_configure_file (LIBRARY_NAME libiconv 
+  INPUT srclib/unitypes.in.h 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/unitypes.h )
+
+iconv_configure_file (LIBRARY_NAME libcharset
+  INPUT libcharset/include/libcharset.h.in 
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/libcharset.h )
 
 # Dirty fix for MinGW
 if ( MINGW )
@@ -49,7 +55,7 @@ if ( MINGW )
 endif ()
 
 include_directories ( ${CMAKE_CURRENT_SOURCE_DIR} include srclib )
-add_definitions ( -Dset_relocation_prefix=libcharset_set_relocation_prefix -Drelocate=libcharset_relocate -DHAVE_CONFIG_H -DINSTALLPREFIX=NULL -DNO_XMALLOC -DBUILDING_LIBCHARSET -DINSTALLDIR="" -DLIBDIR="" -DENABLE_RELOCATABLE=1 -DBUILDING_DLL -DIN_LIBRARY )
+add_definitions ( -Dset_relocation_prefix=libcharset_set_relocation_prefix -Drelocate=libcharset_relocate -DHAVE_CONFIG_H -DINSTALLPREFIX=NULL -DNO_XMALLOC -DBUILDING_LIBCHARSET -DINSTALLDIR="" -DLIBDIR="" -DENABLE_RELOCATABLE=1 -DIN_LIBRARY )
 
 # libcharset
 set ( SRC_LIBCHARSET
@@ -57,8 +63,13 @@ set ( SRC_LIBCHARSET
   libcharset/lib/relocatable.c
 )
 
-add_library ( charset STATIC ${SRC_LIBCHARSET} )
-set_target_properties ( charset PROPERTIES COMPILE_FLAGS -DBUILDING_LIBCHARSET)
+if (MSVC)
+  add_library ( charset STATIC ${SRC_LIBCHARSET} )
+else()
+  add_library ( charset ${SRC_LIBCHARSET} )
+  target_compile_options(charset PRIVATE -DBUILDING_DLL)
+endif()
+target_compile_options ( charset PRIVATE -DBUILDING_LIBCHARSET)
 
 if (NOT MSVC)
   # libicrt
@@ -101,5 +112,6 @@ if(NOT MSVC)
 endif()
 
 install_library ( iconv charset )
-install_header ( include/iconv.h )
+install_header ( ${CMAKE_CURRENT_BINARY_DIR}/include/iconv.h )
+install_header ( ${CMAKE_CURRENT_BINARY_DIR}/include/libcharset.h )
 install_data ( README AUTHORS COPYING )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set ( HAVE_WCHAR_T 0)
 # setup default include directories 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
-configure_file ( config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
+configure_file ( config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/config.h )
 
 iconv_configure_file (LIBRARY_NAME libiconv 
   INPUT include/iconv.h.build.in 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ iconv_configure_file (LIBRARY_NAME libiconv
 
 iconv_configure_file (LIBRARY_NAME libiconv 
   INPUT srclib/unistd.in.h 
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/unistd.h)
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srclib/unistd.h @ONLY)
 
 iconv_configure_file (LIBRARY_NAME libiconv 
   INPUT srclib/unitypes.in.h 

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -328,18 +328,17 @@ macro(iconv_configure_file)
   set(multiValueArgs)
   cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   
-  string(TOUPPER ${arg_LIBRARY_NAME} arg_library_name_upper)
-  set(HAVE_VISIBILITY
-  "WIN32
-    #if defined(${arg_LIBRARY_NAME}_EXPORTS)
-      #define ${arg_library_name_upper}_DLL_EXPORTED __declspec(dllexport)
-    #else
-      #define ${arg_library_name_upper}_DLL_EXPORTED __declspec(dllimport)
-    #endif
-#elif true"
-  )
-  configure_file(
-    ${arg_INPUT}
-    ${arg_OUTPUT}
+  if(MSVC)
+    string(TOUPPER ${arg_LIBRARY_NAME} arg_library_name_upper)
+    set(HAVE_VISIBILITY
+    "WIN32
+      #if defined(${arg_LIBRARY_NAME}_EXPORTS)
+        #define ${arg_library_name_upper}_DLL_EXPORTED __declspec(dllexport)
+      #else
+        #define ${arg_library_name_upper}_DLL_EXPORTED __declspec(dllimport)
+      #endif
+  #elif true"
     )
+  endif()
+  configure_file(${arg_INPUT} ${arg_OUTPUT} @ONLY)
 endmacro()

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -159,11 +159,16 @@ macro ( install_library )
       set_target_properties ( ${_file} PROPERTIES VERSION ${DIST_VERSION}
                               SOVERSION ${DIST_VERSION} )
     endif ()
-    install ( TARGETS ${_file}
+    install ( TARGETS ${_file} EXPORT iconv_targets
               RUNTIME DESTINATION ${INSTALL_BIN} COMPONENT Runtime
               LIBRARY DESTINATION ${INSTALL_LIB} COMPONENT Runtime 
               ARCHIVE DESTINATION ${INSTALL_LIB} COMPONENT Library )
   endforeach()
+
+  install(EXPORT iconv_targets
+          DESTINATION cmake
+          COMPONENT cmake)
+
 endmacro ()
 
 # helper function for various install_* functions, for PATTERN/REGEX args.

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -325,7 +325,10 @@ set ( CPACK_PACKAGE_VENDOR "LuaDist" )
 set ( CPACK_COMPONENTS_ALL Runtime Library Header Data Documentation Example Other )
 include ( CPack )
 
-
+## Configure file replacement that patches some header files when building on 
+## Microsoft Visual Studio Compilers 
+## If not MSVC this function will fall back to the default configure_file 
+## implementation from cmake 
 macro(iconv_configure_file)
   include(CMakeParseArguments)
   set(options)
@@ -345,5 +348,5 @@ macro(iconv_configure_file)
   #elif true"
     )
   endif()
-  configure_file(${arg_INPUT} ${arg_OUTPUT} @ONLY)
+  configure_file(${arg_INPUT} ${arg_OUTPUT} ${arg_UNPARSED_ARGUMENTS})
 endmacro()

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -319,3 +319,27 @@ set ( CPACK_PACKAGE_VERSION "${DIST_VERSION}")
 set ( CPACK_PACKAGE_VENDOR "LuaDist" )
 set ( CPACK_COMPONENTS_ALL Runtime Library Header Data Documentation Example Other )
 include ( CPack )
+
+
+macro(iconv_configure_file)
+  include(CMakeParseArguments)
+  set(options)
+  set(oneValueArgs LIBRARY_NAME INPUT OUTPUT)
+  set(multiValueArgs)
+  cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  
+  string(TOUPPER ${arg_LIBRARY_NAME} arg_library_name_upper)
+  set(HAVE_VISIBILITY
+  "WIN32
+    #if defined(${arg_LIBRARY_NAME}_EXPORTS)
+      #define ${arg_library_name_upper}_DLL_EXPORTED __declspec(dllexport)
+    #else
+      #define ${arg_library_name_upper}_DLL_EXPORTED __declspec(dllimport)
+    #endif
+#elif true"
+  )
+  configure_file(
+    ${arg_INPUT}
+    ${arg_OUTPUT}
+    )
+endmacro()

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -337,7 +337,7 @@ macro(iconv_configure_file)
   cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   
   if(MSVC)
-    string(TOUPPER ${arg_LIBRARY_NAME} arg_library_name_upper)
+    string(TOUPPER "lib${arg_LIBRARY_NAME}" arg_library_name_upper)
     set(HAVE_VISIBILITY
     "WIN32
       #if defined(${arg_LIBRARY_NAME}_EXPORTS)

--- a/include/iconv.h.build.in
+++ b/include/iconv.h.build.in
@@ -28,7 +28,17 @@
 #else
 #define LIBICONV_DLL_EXPORTED
 #endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern LIBICONV_DLL_EXPORTED @DLL_VARIABLE@ int _libiconv_version; /* Likewise */
+
+#ifdef __cplusplus
+}
+#endif
+
 
 /* We would like to #include any system header file which could define
    iconv_t, 1. in order to eliminate the risk that the user gets compilation

--- a/lib/relocatable.h
+++ b/lib/relocatable.h
@@ -32,7 +32,11 @@ extern "C" {
    this is a private .h file, we don't need to use __declspec(dllimport)
    in any case.  */
 #if HAVE_VISIBILITY && BUILDING_DLL
+# if !_MSC_VER
 # define RELOCATABLE_DLL_EXPORTED __attribute__((__visibility__("default")))
+# else
+# define RELOCATABLE_DLL_EXPORTED __declspec(dllexport)
+# endif
 #elif defined _MSC_VER && BUILDING_DLL
 # define RELOCATABLE_DLL_EXPORTED __declspec(dllexport)
 #else

--- a/libcharset/lib/relocatable.h
+++ b/libcharset/lib/relocatable.h
@@ -32,11 +32,7 @@ extern "C" {
    this is a private .h file, we don't need to use __declspec(dllimport)
    in any case.  */
 #if HAVE_VISIBILITY && BUILDING_DLL
-# if !_MSC_VER
 # define RELOCATABLE_DLL_EXPORTED __attribute__((__visibility__("default")))
-# else
-# define RELOCATABLE_DLL_EXPORTED __declspec(dllexport)
-# endif
 #elif defined _MSC_VER && BUILDING_DLL
 # define RELOCATABLE_DLL_EXPORTED __declspec(dllexport)
 #else

--- a/libcharset/lib/relocatable.h
+++ b/libcharset/lib/relocatable.h
@@ -32,7 +32,11 @@ extern "C" {
    this is a private .h file, we don't need to use __declspec(dllimport)
    in any case.  */
 #if HAVE_VISIBILITY && BUILDING_DLL
+# if !_MSC_VER
 # define RELOCATABLE_DLL_EXPORTED __attribute__((__visibility__("default")))
+# else
+# define RELOCATABLE_DLL_EXPORTED __declspec(dllexport)
+# endif
 #elif defined _MSC_VER && BUILDING_DLL
 # define RELOCATABLE_DLL_EXPORTED __declspec(dllexport)
 #else


### PR DESCRIPTION
Hello LuaDist,
thanks for the great CMake adaption of libiconv. Sadly it was not working with Microsoft Visual Studio compilers for different reasons. I took the time to patch the CMake system the enable MSVC support. The changes are agnostic to your environment and are only done in the CMake part of the  project. 

The following changes have been made
- Added support for MSVC by removing the "BUILDING_DLL" definition for "charset" when building.
- Disabled libconvcli for MSVC builds
- Disabled icrt for MSVC builds
- Configured files are now allways written into the CMAKE_CURRENT_BUILD_DIR
- Config headers are patched for proper __declspec(dllexport), __declspec(dllimport) handling
- CMake export targets have been created for easier re-use of the library

Cheers,
Matthias