### PR TITLE
adapted library naming for MSVC build. Some libraries using iconv hea…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,12 @@ set ( SRC_LIBCHARSET
 )
 
 add_library ( charset ${SRC_LIBCHARSET} )
-if(NOT MSVC)
-  target_compile_options(charset PRIVATE -DBUILDING_DLL)
+if ( NOT MSVC )
+  target_compile_options (charset PRIVATE -DBUILDING_DLL)
 endif()
 target_compile_options (charset PRIVATE -DBUILDING_LIBCHARSET)
 
-if (NOT MSVC)
+if ( NOT MSVC )
   # libicrt
   set ( SRC_LIBICRT 
     srclib/allocator.c
@@ -111,6 +111,12 @@ if(NOT MSVC)
   set_target_properties ( iconvcli PROPERTIES OUTPUT_NAME iconv )
 
   install_executable ( iconvcli )
+endif()
+
+# fix library naming for Visual Studio compilers
+if(MSVC)
+  set_target_properties ( iconv   PROPERTIES OUTPUT_NAME "libiconv" )
+  set_target_properties ( charset PROPERTIES OUTPUT_NAME "libcharset" )
 endif()
 
 install_library ( iconv charset )


### PR DESCRIPTION
…vily relay on naming patterns (see dcmtk)

Hi, me again.

I had to adapt the naming of the MSVC created libraries. 'iconv' and 'charset' are now also exported as 'libiconv' and 'libcharset' since a lot of libraries using iconv heavily relay on this naming pattern.

Side Note:
I'm experiencing issues with the Travis CI since it works on a CMake-Version < 3.0. The problems come with the target_compile_options that have been introduced later. If you are experiencing the same issues, a you'd like to support this 4 year old CMake version I will need to work on the CMakeLists.txt again... 